### PR TITLE
feat: Add extra k6 extensions

### DIFF
--- a/.github/workflows/xk6bundler.yml
+++ b/.github/workflows/xk6bundler.yml
@@ -23,7 +23,7 @@ jobs:
             github.com/szkiba/xk6-cache@v0.1.1
             github.com/szkiba/xk6-dotenv@v0.1.1
             github.com/szkiba/xk6-mock@v0.1.2
-            github.com/szkiba/xk6-faker@v0.2.0
+            github.com/szkiba/xk6-faker@latest
             github.com/szkiba/xk6-crypto@v0.1.3
             github.com/szkiba/xk6-jose@v0.1.2
             github.com/szkiba/xk6-yaml@v0.1.2
@@ -33,7 +33,6 @@ jobs:
             github.com/dgzlopes/xk6-remote-write@latest
             github.com/dgzlopes/xk6-notification@latest
             github.com/imiric/xk6-sql@latest
-            github.com/szkiba/xk6-mock@latest
             github.com/k6io/xk6-distributed-tracing@latest
 
       - name: Create Release

--- a/.github/workflows/xk6bundler.yml
+++ b/.github/workflows/xk6bundler.yml
@@ -38,27 +38,28 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v3
-        with:
-          images: ${{ secrets.DOCKERHUB_USERNAME }}/${{ steps.build.outputs.name }}
-          tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
+      # Disable the generation and pushing of docker images to Docker Hub
+      # - name: Docker meta
+      #   id: meta
+      #   uses: docker/metadata-action@v3
+      #   with:
+      #     images: ${{ secrets.DOCKERHUB_USERNAME }}/${{ steps.build.outputs.name }}
+      #     tags: |
+      #       type=semver,pattern={{version}}
+      #       type=semver,pattern={{major}}.{{minor}}
+      #       type=semver,pattern={{major}}
 
-      - name: Login to DockerHub
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      # - name: Login to DockerHub
+      #   uses: docker/login-action@v1
+      #   with:
+      #     username: ${{ secrets.DOCKERHUB_USERNAME }}
+      #     password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Docker build and push
-        if: startsWith(github.ref, 'refs/tags/')
-        uses: docker/build-push-action@v2
-        with:
-          push: true
-          context: ./${{ steps.build.outputs.dockerdir }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+      # - name: Docker build and push
+      #   if: startsWith(github.ref, 'refs/tags/')
+      #   uses: docker/build-push-action@v2
+      #   with:
+      #     push: true
+      #     context: ./${{ steps.build.outputs.dockerdir }}
+      #     tags: ${{ steps.meta.outputs.tags }}
+      #     labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/xk6bundler.yml
+++ b/.github/workflows/xk6bundler.yml
@@ -29,7 +29,12 @@ jobs:
             github.com/szkiba/xk6-yaml@v0.1.2
             github.com/szkiba/xk6-toml@v0.1.2
             github.com/szkiba/xk6-csv@v0.1.2
-            github.com/szkiba/xk6-ansible-vault@v0.1.2
+            github.com/olvod/xk6-pubsub@latest
+            github.com/dgzlopes/xk6-remote-write@latest
+            github.com/dgzlopes/xk6-notification@latest
+            github.com/imiric/xk6-sql@latest
+            github.com/szkiba/xk6-mock@latest
+            github.com/k6io/xk6-distributed-tracing@latest
 
       - name: Create Release
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
Add useful k6 extensions to the extensions:

 - Add Google PubSub messaging support
 - Add Slack notification support so a message can be send when tests are finished 
 - Add support for accessing Postgresql database in tests
 - Add Prometheus Remote Write so metrics can be pushed to Prometheus instead of scraping to avoid needing to keep the tests continuously running
 - Add distributed tracing support to ease observability via Opentelemetry